### PR TITLE
Code coverage via nyc

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,10 @@
+{
+  "reporter": ["lcov"],
+  "all": true,
+  "check-coverage": true,
+  "branches": 50,
+  "lines": 50,
+  "functions": 50,
+  "statements": 50,
+  "exclude": ["dist/", "coverage/", "docs", ".nyc_output/", "test/"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2477,9 +2477,9 @@
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -2522,15 +2522,14 @@
       }
     },
     "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "dependencies": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
         "uuid": "^8.3.2"
@@ -3350,7 +3349,7 @@
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-hook": "^3.0.0",
         "istanbul-lib-instrument": "^4.0.0",
-        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-processinfo": "^2.0.3",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha test/**/*spec.ts",
-    "makeCodeCoverageDetailReport": "nyc --all --exclude migrations --exclude coverage --exclude test --reporter lcov --reporter html  npm test -- --reporter dot && echo \"*** Code coverage report done, checkout ./coverage dir\"",
-    "makeCodeCoverageSummaryReport": "nyc --all --exclude migrations --exclude coverage --exclude test --reporter text-summary npm test -- --reporter dot"
+    "coverage": "nyc npm test"
   },
   "keywords": [
     "express-rate-limit",


### PR DESCRIPTION
## Using nyc to generate Code Coverage (#21)

Adapting the nyc, which is an Istanbuljs CLI, to generate code coverage reports for us.

## Changes
Fixed: #22 with dependency update
Configured nyc with a specific dotfile(`.nycrc.json`)
Removed old coverage report scripts from the package.json
Add new `coverage` script to run script via npm easily